### PR TITLE
Minimize syntax errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -456,7 +456,7 @@ CodeMirror.defineMode("nim", (conf, parserConf) => {
 
     // Handle non-detected items
     stream.next();
-    return ERRORCLASS;
+    return null;
   }
 
   function tokenStringFactory(delimiter) {
@@ -569,8 +569,8 @@ CodeMirror.defineMode("nim", (conf, parserConf) => {
 
     // Handle '.' connected identifiers
     if (current === ".") {
-      style = stream.match(identifiers, false) ? null : ERRORCLASS;
-      if (style === null && state.lastStyle === "meta") {
+      style = null;
+      if (state.lastStyle === "meta") {
         // Apply 'meta' style to '.' connected identifiers when
         // appropriate.
         style = "meta";


### PR DESCRIPTION
The Nim playground does not have CSS for syntax errors even though this script returns multiple errors, and these errors can be in the wrong places. Examples are given in https://github.com/codewars/codewars.com/issues/2243#issuecomment-693146337 and https://github.com/codewars/codewars.com/issues/2243#issuecomment-694388915. Better logic for handling invalid syntax could be implemented but for now it should be kept simple.