### PR TITLE
Improve compatibility with CM6

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/stisa/nim-codemirror-mode.git"
   },
   "peerDependencies": {
-    "codemirror": "^5.56.0"
+    "codemirror": "^5.56.0 || ^6"
   },
   "keywords": [
     "nim",


### PR DESCRIPTION
Now that CM6 is out and has an NPM package this allows one to install both this mode and CM6:
```json
{
  "dependencies": {
    "codemirror": "6",
    "nim-codemirror-mode": ""
  },
}
```
ATM it dies with this despite this mode working fine under back-compat with CM6:
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: undefined@undefined
npm ERR! Found: codemirror@6.0.0
npm ERR! node_modules/codemirror
npm ERR!   codemirror@"6" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer codemirror@"^5.56.0" from nim-codemirror-mode@0.3.0
npm ERR! node_modules/nim-codemirror-mode
npm ERR!   nim-codemirror-mode@"" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```